### PR TITLE
added CMake code to find MassiveThreads and removed hard-coded path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,37 @@
 cmake_minimum_required(VERSION 2.8)
 
+# --------------------------------------------------------------------------------
+# Find MassiveThreads
+# MassiveThreads is available via https://code.google.com/p/massivethreads/
+# TODO: split this part as a FindMassiveThreads module.
+
+find_path(MYTH_INCLUDE_DIR
+  NAMES "mtbb/task_group.h"
+  PATHS $ENV{MYTH_ROOT}/include ${MYHT_ROOT}/include /usr/local/include)
+set(MYTH_INCLUDE_DIRS ${MYTH_INCLUDE_DIR})
+    
+find_library(MYTH_LIBRARY
+  NAMES "myth-native"
+  PATHS $ENV{MYTH_ROOT}/lib ${MYTH_ROOT}/lib /usr/local/lib
+  STATIC)
+set(MYTH_LIBRARIES ${MYTH_LIBRARY})
+message(STATUS ${MYTH_LIBRARY})
+
+mark_as_advanced(MYTH_INCLUDE_DIRS MYTH_LIBRARIES)
+
+if (IS_DIRECTORY MYTH_INCLUDE_DIR AND IS_DIRECTORY MYTH_LIBRARY)
+  message(STATUS "Found MassiveThreads in ${MYHT_INCLUDE_DIR}")
+  set(MYTH_FOUND 1)
+endif()
+
+# --------------------------------------------------------------------------------
+
+message(STATUS "Compiler = ${CMAKE_CXX_COMPILER_ID}")
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -ggdb3 -Wall -O2")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funroll-loops -fcolor-diagnostics")
+endif()
+
 add_subdirectory(sample)
 

--- a/sample/exafmm-dev-13274dd4ac68/CMakeLists.txt
+++ b/sample/exafmm-dev-13274dd4ac68/CMakeLists.txt
@@ -4,11 +4,6 @@ set(EXAFMM_EXPANSION 4          CACHE STRING "Length of expansion")
 set(EXAFMM_FP64      True       CACHE BOOL   "Use double")
 set(EXAFMM_DEVICE    "CPU")
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -ggdb3 -Wall -O2")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funroll-loops -fcolor-diagnostics")
-endif()
-
 if (EXAFMM_FP64)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFP64")
 endif()


### PR DESCRIPTION
Added CMake code to find MassiveThreads and removed hard-coded path

Plus moved some CMake code to tapas/CMake.
(In future, the code will be moved to tapas/FindTapas.cmake, which provides TAPAS_CXX_FALGS etc.)
